### PR TITLE
Release 2209 updates for Literature ETL

### DIFF
--- a/configurations/2022/22.09_json.conf
+++ b/configurations/2022/22.09_json.conf
@@ -1,0 +1,7 @@
+// Bucket name information
+bucketName = "open-targets-pre-data-releases"
+// Release information
+releaseNumber = "22.09"
+epmcReleaseNumber = "22.01"
+// Output configuration
+common.output-format = "json"

--- a/configurations/2022/22.09_parquet.conf
+++ b/configurations/2022/22.09_parquet.conf
@@ -1,0 +1,7 @@
+// Bucket name information
+bucketName = "open-targets-pre-data-releases"
+// Release information
+releaseNumber = "22.09"
+epmcReleaseNumber = "22.01"
+// Output configuration
+common.output-format = "parquet"

--- a/src/main/scala/io/opentargets/etl/literature/spark/Helpers.scala
+++ b/src/main/scala/io/opentargets/etl/literature/spark/Helpers.scala
@@ -39,6 +39,8 @@ object Helpers extends LazyLogging {
       .set("spark.driver.maxResultSize", "0")
       .set("spark.debug.maxToStringFields", "2000")
       .set("spark.sql.mapKeyDedupPolicy", "LAST_WIN")
+      // TODO - Externalize this to a configuration parameter (put in here for literature pipeline)
+      .set("spark.sql.broadcastTimeout", "3000")
 
     // if some uri then setmaster must be set otherwise
     // it tries to get from env if any yarn running


### PR DESCRIPTION
This PR groups the updates used for the literature pipeline in 22.09 release, including the changes in the Spark cluster broadcast timeout configuration.